### PR TITLE
Try canonical constructor for records if no @JsonbCreator

### DIFF
--- a/src/main/java/io/github/asvanberg/donkey/deserializing/Util.java
+++ b/src/main/java/io/github/asvanberg/donkey/deserializing/Util.java
@@ -1,13 +1,26 @@
 package io.github.asvanberg.donkey.deserializing;
 
+import io.github.asvanberg.donkey.exceptions.InternalProcessingException;
 import io.github.asvanberg.donkey.exceptions.UnexpectedParserPositionException;
 import jakarta.json.stream.JsonParser;
+
+import java.util.concurrent.Callable;
 
 class Util {
     static void assertCurrentParserPosition(final JsonParser.Event expected, final JsonParser parser) {
         final JsonParser.Event event = parser.next();
         if (event != expected) {
             throw new UnexpectedParserPositionException(expected, event);
+        }
+    }
+
+    static <A> A throwing(Callable<A> f)
+    {
+        try {
+            return f.call();
+        }
+        catch (Exception e) {
+            throw new InternalProcessingException(e);
         }
     }
 }


### PR DESCRIPTION
If attempting to deserialize into a record, try the canonical constructor if no `@JsonbCreator` is found. Helps reduce the boilerplate required when working with records. The `@JsonbProperty` requirement for parameters, however, is still there to maintain the safety and freedom to refactor their names.