### PR TITLE
Compile time annotation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ An implementation of [Jakarta JSON processing](https://github.com/eclipse-ee4j/j
 
 ### Annotation processing
 Donkey comes with an annotation processing module located at `io.github.asvanberg:donkey-apt`.
-It is *highly* recommended using this module as it increases serialization performance.
+It is *highly* recommended using this module as it;
+* increases serialization performance
+* checks usage of annotations to turn what would be runtime errors into compile time errors
 
 If you are building a modular application you have to explicitly configure the annotation processor by adding the
 artifact coordinates to the Maven compiler configuration using [annotation processor paths](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths).

--- a/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckCreator.java
+++ b/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckCreator.java
@@ -1,0 +1,23 @@
+package io.github.asvanberg.donkey.apt;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.tools.Diagnostic;
+
+abstract class CheckCreator extends AbstractProcessor
+{
+    void check(ExecutableElement e)
+    {
+        for (VariableElement parameter : e.getParameters()) {
+            JsonbProperty jsonbProperty = parameter.getAnnotation(JsonbProperty.class);
+            if (jsonbProperty == null) {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "Missing @JsonbProperty on parameter " + parameter, parameter);
+            }
+        }
+    }
+}

--- a/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckJsonbCreatorParameters.java
+++ b/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckJsonbCreatorParameters.java
@@ -1,0 +1,52 @@
+package io.github.asvanberg.donkey.apt;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.Set;
+
+/**
+ * Verifies that methods/constructors annotated with {@link JsonbCreator}
+ * have all their parameters annotated with
+ * {@link jakarta.json.bind.annotation.JsonbProperty JsonbProperty}.
+ */
+public final class CheckJsonbCreatorParameters extends CheckCreator
+{
+    @Override
+    public SourceVersion getSupportedSourceVersion()
+    {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes()
+    {
+        return Set.of(JsonbCreator.class.getName());
+    }
+
+    @Override
+    public boolean process(
+            Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(JsonbCreator.class);
+        check(ElementFilter.constructorsIn(elements));
+        check(ElementFilter.methodsIn(elements));
+        return false;
+    }
+
+    private void check(Set<ExecutableElement> creators)
+    {
+        for (ExecutableElement e : creators) {
+            check(e);
+        }
+    }
+}

--- a/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckJsonbPropertyValue.java
+++ b/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckJsonbPropertyValue.java
@@ -1,0 +1,53 @@
+package io.github.asvanberg.donkey.apt;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import java.util.Set;
+
+/**
+ * Verifies that all parameters annotated with {@link JsonbProperty}
+ * have their {@link JsonbProperty#value()} set
+ */
+public final class CheckJsonbPropertyValue extends AbstractProcessor
+{
+    @Override
+    public SourceVersion getSupportedSourceVersion()
+    {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes()
+    {
+        return Set.of(JsonbProperty.class.getName());
+    }
+
+    @Override
+    public boolean process(
+            Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(JsonbProperty.class);
+        for (Element e : elements) {
+            if (e.getKind() == ElementKind.PARAMETER) {
+                JsonbProperty jsonbProperty = e.getAnnotation(JsonbProperty.class);
+                if (jsonbProperty.value().isBlank()) {
+                    processingEnv.getMessager().printMessage(
+                            Diagnostic.Kind.ERROR,
+                            "Missing @JsonbProperty value on parameter " + e, e);
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckRecordCanonicalConstructorParameters.java
+++ b/apt/src/main/java/io/github/asvanberg/donkey/apt/CheckRecordCanonicalConstructorParameters.java
@@ -1,0 +1,80 @@
+package io.github.asvanberg.donkey.apt;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.RecordComponentElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.Types;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Checks records canonical constructor parameters,
+ * if any of them are annotated with {@link JsonbProperty}
+ * then the others must be as well.
+ */
+public final class CheckRecordCanonicalConstructorParameters extends CheckCreator
+{
+    @Override
+    public SourceVersion getSupportedSourceVersion()
+    {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes()
+    {
+        return Set.of(JsonbProperty.class.getName());
+    }
+
+    @Override
+    public boolean process(
+            Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(JsonbProperty.class);
+        for (Element e : elements) {
+            if (e.getKind() == ElementKind.PARAMETER) {
+                Element maybeConstructor = e.getEnclosingElement();
+                if (maybeConstructor.getKind() == ElementKind.CONSTRUCTOR) {
+                    Element maybeRecord = maybeConstructor.getEnclosingElement();
+                    if (maybeRecord.getKind() == ElementKind.RECORD) {
+                        TypeElement record = (TypeElement) maybeRecord;
+                        ExecutableElement constructor = (ExecutableElement) maybeConstructor;
+                        if (isCanonical(constructor, record)) {
+                            check(constructor);
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isCanonical(ExecutableElement constructor, TypeElement record)
+    {
+        List<? extends RecordComponentElement> recordComponents = record.getRecordComponents();
+        List<? extends VariableElement> parameters = constructor.getParameters();
+        if (recordComponents.size() != parameters.size()) {
+            return false;
+        }
+        Types types = processingEnv.getTypeUtils();
+        for (int i = 0; i < recordComponents.size(); i++) {
+            RecordComponentElement rc = recordComponents.get(i);
+            VariableElement pc = parameters.get(i);
+            if (!types.isSameType(rc.asType(), pc.asType())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/apt/src/main/java/module-info.java
+++ b/apt/src/main/java/module-info.java
@@ -7,6 +7,8 @@ module io.github.asvanberg.donkey.apt {
     requires transitive jakarta.json.bind;
     provides javax.annotation.processing.Processor with
             io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue,
+            io.github.asvanberg.donkey.apt.CheckJsonbCreatorParameters,
+            io.github.asvanberg.donkey.apt.CheckRecordCanonicalConstructorParameters,
             io.github.asvanberg.donkey.apt.JsonbSerializerGenerator;
 
     exports io.github.asvanberg.donkey.apt;

--- a/apt/src/main/java/module-info.java
+++ b/apt/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module io.github.asvanberg.donkey.apt {
     requires transitive java.compiler;
     requires transitive jakarta.json.bind;
     provides javax.annotation.processing.Processor with
+            io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue,
             io.github.asvanberg.donkey.apt.JsonbSerializerGenerator;
 
     exports io.github.asvanberg.donkey.apt;

--- a/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
 io.github.asvanberg.donkey.apt.JsonbSerializerGenerator
+io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue

--- a/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,2 +1,4 @@
 io.github.asvanberg.donkey.apt.JsonbSerializerGenerator
 io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue
+io.github.asvanberg.donkey.apt.CheckJsonbCreatorParameters
+io.github.asvanberg.donkey.apt.CheckRecordCanonicalConstructorParameters


### PR DESCRIPTION
If the annotation processing module is enabled the following checks will be made;
* All parameters annotated with `@JsonbProperty` must have an explicit `value`
* Methods and constructors annotated with `@JsonbCreator` must have all their parameters annotated with `@JsonbProperty`
* If any parameter in a records canonical constructor is annotated with `@JsonbProperty` the rest must be so as well

This does not enforce `value` to be set on public methods `@JsonbProperty` since this would be inconsistent with how the serializer works and would be a backwards breaking change since they are currently ignored rather than failing at runtime.