### PR TITLE
Generate deserializers at compile time via annotation processing

### DIFF
--- a/apt/pom.xml
+++ b/apt/pom.xml
@@ -22,6 +22,21 @@
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apt/src/main/java/io/github/asvanberg/donkey/apt/JsonbDeserializerGenerator.java
+++ b/apt/src/main/java/io/github/asvanberg/donkey/apt/JsonbDeserializerGenerator.java
@@ -1,0 +1,253 @@
+package io.github.asvanberg.donkey.apt;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class JsonbDeserializerGenerator extends AbstractProcessor
+{
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(JsonbCreator.class.getName());
+    }
+
+    @Override
+    public boolean process(
+            Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(JsonbCreator.class);
+        ElementFilter.constructorsIn(elements).forEach(this::generateDeserializer);
+        ElementFilter.methodsIn(elements).forEach(this::generateDeserializer);
+        return false;
+    }
+
+    private void generateDeserializer(ExecutableElement executableElement) {
+        Element enclosingElement = executableElement.getEnclosingElement();
+        ElementKind enclosingKind = enclosingElement.getKind();
+        assert enclosingKind == ElementKind.CLASS || enclosingKind == ElementKind.RECORD;
+        List<? extends VariableElement> parameters = executableElement.getParameters();
+        int arg = 0;
+        StringBuilder initializers = new StringBuilder();
+        StringBuilder matchers = new StringBuilder();
+        StringBuilder statics = new StringBuilder();
+        for (VariableElement parameter : parameters) {
+            TypeMirror type = parameter.asType();
+            initializers.append(propertyInitializer(arg, type));
+            matchers.append(propertyCase(arg, parameter));
+            statics.append(appendTypeReference(arg, parameter));
+            arg++;
+        }
+        String argsFound = IntStream.range(0, arg)
+                                  .mapToObj(i -> "arg" + i + "_found")
+                                  .collect(Collectors.joining(" && "));
+        String args = IntStream.range(0, arg)
+                                  .mapToObj(i -> "arg" + i)
+                                  .collect(Collectors.joining(", "));
+        String callCreator = executableElement.getKind() == ElementKind.CONSTRUCTOR
+                ? "new %s".formatted(enclosingElement)
+                : "%s.%s".formatted(enclosingElement, executableElement.getSimpleName());
+        String create = """
+                if (%s) {
+                    return %s(%s);
+                }
+                else {
+                    throw new JsonbException("Properties missing");
+                }
+                """.formatted(argsFound, callCreator, args);
+        Elements elements = processingEnv.getElementUtils();
+        String package_ = elements.getPackageOf(enclosingElement).toString();
+        String className = enclosingElement.getSimpleName() + "$donkey$apt$deserializer";
+        String source = deserializerSource(
+                package_,
+                className,
+                enclosingElement.asType().toString(),
+                statics,
+                methodBody(initializers, matchers, create));
+        Filer filer = processingEnv.getFiler();
+        try {
+            JavaFileObject sourceFile
+                    = filer.createSourceFile(package_ + "." + className, enclosingElement);
+            try (var os = new OutputStreamWriter(sourceFile.openOutputStream(), StandardCharsets.UTF_8)) {
+                os.write(source);
+            }
+        }
+        catch (IOException e) {
+            processingEnv.getMessager().printMessage(
+                    Diagnostic.Kind.WARNING,
+                    "Failed to generate deserializer: " + e.getMessage(), executableElement);
+        }
+    }
+
+    private CharSequence propertyInitializer(
+            int i,
+            TypeMirror type)
+    {
+        return """
+                boolean arg%d_found = %s;
+                %s arg%1$d = %s;
+                """
+                .formatted(i, isOptional(type), type, getDefault(type));
+    }
+
+    private String getDefault(TypeMirror type) {
+        return switch (type.getKind()) {
+            case BOOLEAN -> "false";
+            case BYTE, LONG, CHAR, INT, SHORT, DOUBLE, FLOAT -> "0";
+            default -> {
+                if (type instanceof DeclaredType declaredType && isOptional(type)) {
+                    yield declaredType.asElement() + ".empty()";
+                }
+                else {
+                    yield "null";
+                }
+            }
+        };
+    }
+
+    private boolean isOptional(TypeMirror type) {
+        return type.toString().startsWith("java.util.Optional");
+    }
+
+    private String propertyCase(int arg, VariableElement parameter) {
+        String propertyName = parameter.getAnnotation(JsonbProperty.class).value();
+        JsonbDateFormat jsonbDateFormat = parameter.getAnnotation(JsonbDateFormat.class);
+        if (jsonbDateFormat != null
+                && !jsonbDateFormat.value().equals(JsonbDateFormat.DEFAULT_FORMAT))
+        {
+            return """
+                    case "%s" -> {
+                        arg%d_found = true;
+                        parser.next();
+                        arg%2$d = ARG_%2$d_FORMAT.parse(parser.getString(), %s::from);
+                    }
+                    """.formatted(propertyName, arg, parameter.asType());
+        }
+        return """
+                case "%s" -> {
+                    arg%d_found = true;
+                    arg%2$d = ctx.deserialize(ARG_%2$d_TYPE, parser);
+                }
+                """.formatted(propertyName, arg);
+    }
+
+    private String appendTypeReference(int arg, VariableElement parameter) {
+        JsonbDateFormat jsonbDateFormat = parameter.getAnnotation(JsonbDateFormat.class);
+        if (jsonbDateFormat != null
+                && !jsonbDateFormat.value().equals(JsonbDateFormat.DEFAULT_FORMAT))
+        {
+            if (jsonbDateFormat.locale().equals(JsonbDateFormat.DEFAULT_LOCALE)) {
+                return """
+                        private static final java.time.format.DateTimeFormatter ARG_%d_FORMAT
+                             = java.time.format.DateTimeFormatter.ofPattern("%s");
+                        """.formatted(arg, jsonbDateFormat.value());
+            }
+            else {
+                return """
+                        private static final java.time.format.DateTimeFormatter ARG_%d_FORMAT
+                             = java.time.format.DateTimeFormatter.ofPattern("%s", java.util.Locale.forLanguageTag("%s"));
+                        """.formatted(arg, jsonbDateFormat.value(), jsonbDateFormat.locale());
+            }
+        }
+        TypeMirror type = parameter.asType();
+        if (type.getKind() == TypeKind.DECLARED) {
+            return """
+                    private static final Type ARG_%d_TYPE;
+                    static {
+                        abstract class GenericType<T>{}
+                        final Type genericSuperclass = new GenericType<%s>(){}.getClass().getGenericSuperclass();
+                        ARG_%1$d_TYPE = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+                    }
+                    """
+                    .formatted(arg, type);
+        }
+        else {
+            return "private static final Type ARG_%d_TYPE = %s.class;"
+                    .formatted(arg, type);
+        }
+    }
+
+    private String methodBody(CharSequence initializers, CharSequence matchers, String create) {
+        return """
+                JsonParser.Event event = parser.next();
+                assert event == JsonParser.Event.START_OBJECT;
+                %s
+                while ((event = parser.next()) != JsonParser.Event.END_OBJECT) {
+                    assert event == JsonParser.Event.KEY_NAME;
+                    switch (parser.getString()) {
+                        %s
+                        default -> {
+                            switch (parser.next()) {
+                                case START_ARRAY -> parser.skipArray();
+                                case START_OBJECT -> parser.skipObject();
+                            }
+                        }
+                    }
+                }
+                %s
+                """.formatted(initializers, matchers, create);
+    }
+
+    private String deserializerSource(
+            String package_,
+            String className,
+            String type,
+            CharSequence statics,
+            String methodBody)
+    {
+        return """
+                package %s;
+                                
+                import jakarta.json.bind.JsonbException;
+                import jakarta.json.bind.serializer.DeserializationContext;
+                import jakarta.json.bind.serializer.JsonbDeserializer;
+                import jakarta.json.stream.JsonParser;
+                import java.lang.reflect.Type;
+                import java.lang.reflect.ParameterizedType;
+                                
+                @javax.annotation.processing.Generated("%s")
+                public class %s implements JsonbDeserializer<%s> {
+                    %s
+                    
+                    @Override
+                    public %4$s deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+                        %s
+                    }
+                }
+                """.formatted(
+                package_,
+                JsonbDeserializerGenerator.class.getName(),
+                className,
+                type,
+                statics,
+                methodBody);
+    }
+}

--- a/apt/src/main/java/module-info.java
+++ b/apt/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module io.github.asvanberg.donkey.apt {
             io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue,
             io.github.asvanberg.donkey.apt.CheckJsonbCreatorParameters,
             io.github.asvanberg.donkey.apt.CheckRecordCanonicalConstructorParameters,
+            io.github.asvanberg.donkey.apt.JsonbDeserializerGenerator,
             io.github.asvanberg.donkey.apt.JsonbSerializerGenerator;
 
     exports io.github.asvanberg.donkey.apt;

--- a/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -2,3 +2,4 @@ io.github.asvanberg.donkey.apt.JsonbSerializerGenerator
 io.github.asvanberg.donkey.apt.CheckJsonbPropertyValue
 io.github.asvanberg.donkey.apt.CheckJsonbCreatorParameters
 io.github.asvanberg.donkey.apt.CheckRecordCanonicalConstructorParameters
+io.github.asvanberg.donkey.apt.JsonbDeserializerGenerator

--- a/apt/src/test/java/io/github/asvanberg/donkey/apt/test/JsonbDeserializerGeneratorTest.java
+++ b/apt/src/test/java/io/github/asvanberg/donkey/apt/test/JsonbDeserializerGeneratorTest.java
@@ -1,0 +1,75 @@
+package io.github.asvanberg.donkey.apt.test;
+
+import io.github.asvanberg.donkey.apt.JsonbDeserializerGenerator;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonbDeserializerGeneratorTest
+{
+    @Test
+    public void compiles_without_warnings()
+            throws Exception
+    {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnosticListener = new DiagnosticCollector<>();
+        try (var fileManager = compiler.getStandardFileManager(
+                diagnosticListener,
+                Locale.getDefault(),
+                StandardCharsets.UTF_8))
+        {
+            String[] dependencyPaths = System.getProperty("jdk.module.path")
+                                             .split(System.getProperty("path.separator"));
+            List<Path> dependencies = Arrays.stream(dependencyPaths)
+                                            .map(Paths::get)
+                                            .collect(Collectors.toList());
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, dependencies);
+            Path outputPath = Paths.get(System.getProperty("user.dir"), "target", "apt");
+
+            Files.createDirectories(outputPath);
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, Set.of(outputPath));
+
+            URL javaFileDirectory = JsonbDeserializerGeneratorTest.class.getResource("/deserializer-generation");
+            assert javaFileDirectory != null;
+            List<Path> javaClassFiles
+                    = Files.list(Paths.get(javaFileDirectory.toURI()))
+                           .collect(Collectors.toList());
+            Iterable<? extends JavaFileObject> javaFileObjects
+                    = fileManager.getJavaFileObjectsFromPaths(javaClassFiles);
+
+            JavaCompiler.CompilationTask task = compiler.getTask(
+                    null,
+                    fileManager,
+                    diagnosticListener,
+                    null,
+                    null,
+                    javaFileObjects);
+            task.setProcessors(Set.of(new JsonbDeserializerGenerator()));
+
+            Boolean compiled = task.call();
+            assertThat(diagnosticListener.getDiagnostics())
+                    .noneMatch(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                    .noneMatch(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.WARNING)
+                    .noneMatch(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.MANDATORY_WARNING);
+            assertThat(compiled)
+                    .isTrue();
+        }
+    }
+}

--- a/apt/src/test/resources/deserializer-generation/Color.java
+++ b/apt/src/test/resources/deserializer-generation/Color.java
@@ -1,0 +1,5 @@
+package deserialization;
+
+public enum Color {
+    RED, GREEN, BLUE;
+}

--- a/apt/src/test/resources/deserializer-generation/Complex.java
+++ b/apt/src/test/resources/deserializer-generation/Complex.java
@@ -1,0 +1,27 @@
+package deserialization;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public record Complex(
+        @JsonbProperty("x") int x,
+        @JsonbProperty("alive") boolean alive,
+        @JsonbProperty("friends") List<String> friends,
+        @JsonbProperty("table") List<List<Integer>> table,
+        @JsonbProperty("favourites") Map<String, List<Color>> favourites,
+        @JsonbProperty("parent") Optional<Complex> parent,
+        @JsonbProperty("birthday") @JsonbDateFormat("yyyyMMdd")LocalDate birthday,
+        @JsonbProperty("wakeUpTime")
+        @JsonbDateFormat(value = "hh:mmaa", locale = "sv")
+        LocalTime wakeUpTime)
+{
+    @JsonbCreator
+    public Complex {}
+}

--- a/apt/src/test/resources/deserializer-generation/Simple.java
+++ b/apt/src/test/resources/deserializer-generation/Simple.java
@@ -1,0 +1,18 @@
+package deserialization;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public class Simple
+{
+    private final boolean flag;
+
+    private Simple(boolean flag) {
+        this.flag = flag;
+    }
+
+    @JsonbCreator
+    public static Simple create(@JsonbProperty("flag") boolean flag) {
+        return new Simple(flag);
+    }
+}

--- a/impl/src/main/java/io/github/asvanberg/donkey/deserializing/ObjectDeserializer.java
+++ b/impl/src/main/java/io/github/asvanberg/donkey/deserializing/ObjectDeserializer.java
@@ -2,6 +2,7 @@ package io.github.asvanberg.donkey.deserializing;
 
 import io.github.asvanberg.donkey.exceptions.MissingPropertyInJsonException;
 import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
 import java.lang.reflect.ParameterizedType;
@@ -17,7 +18,14 @@ class ObjectDeserializer<T> extends NullableDeserializer<T> {
 
     private final Creator<T> creator;
 
-    static <T> ObjectDeserializer<T> of(Class<T> clazz) {
+    @SuppressWarnings("unchecked")
+    static <T> JsonbDeserializer<T> of(Class<T> clazz) {
+        // check if there's an apt generated serializer
+        try {
+            final String deserializerClassName = clazz.getName() + "$donkey$apt$deserializer";
+            return (JsonbDeserializer<T>) Class.forName(deserializerClassName)
+                                                    .getConstructor().newInstance();
+        } catch (Exception ignored) {}
         return new ObjectDeserializer<>(Creator.forClass(clazz));
     }
 

--- a/impl/src/test/java/io/github/asvanberg/donkey/test/AptDeserializerTest.java
+++ b/impl/src/test/java/io/github/asvanberg/donkey/test/AptDeserializerTest.java
@@ -1,0 +1,39 @@
+package io.github.asvanberg.donkey.test;
+
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AptDeserializerTest extends DefaultConfigurationTest
+{
+    public static record Container(String s)
+    {
+    }
+
+    @SuppressWarnings("unused")
+    public static class Container$donkey$apt$deserializer
+            implements JsonbDeserializer<Container>
+    {
+
+        @Override
+        public Container deserialize(
+                JsonParser parser, DeserializationContext ctx, Type rtType)
+        {
+            return new Container("apt");
+        }
+    }
+
+    @Test
+    public void uses_apt_deserializer_if_it_exists()
+    {
+        Container container = jsonb.fromJson("", Container.class);
+        assertThat(container)
+                .extracting(Container::s)
+                .isEqualTo("apt");
+    }
+}


### PR DESCRIPTION
About 15% higher throughput on the deserialize object benchmark.